### PR TITLE
edited email validation regex (empty string allowed) and isNotEmpty rule

### DIFF
--- a/AppForm.jsx
+++ b/AppForm.jsx
@@ -12,7 +12,7 @@ export default function AppForm() {
     type: 'object',
     properties: {
       firstName: { type: 'string', minLength: 1, maxLength: 10 },
-      lastName: { type: 'string', minLength: 1 },
+      lastName: { type: 'string', isNotEmpty: true },
       profession: {
         type: 'string',
         options: [
@@ -79,6 +79,11 @@ export default function AppForm() {
         uniforms: { type: 'phone', format: '+7 ### ###-##-##' },
         minLength: 10,
         maxLength: 10
+      },
+      email: {
+        title: 'E-mail',
+        type: 'string',
+        format: 'email'
       },
       check: { type: 'boolean' },
       zip: { type: 'string', pattern: '[0-9]{5}' },

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,28 @@ ajv.addKeyword('uniforms');
 ajv.addKeyword('options');
 //addFormats(ajv);
 
+// email or empty string
+ajv.addFormat(
+  'email',
+  /(^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$)|(^$)/
+);
+
+ajv.addKeyword('isNotEmpty', {
+  type: 'string',
+  errors: true,
+  validate: function validate(schema, data, parent, key) {
+    validate.errors = [
+      {
+        keyword: 'isNotEmpty',
+        message: 'должно иметь обязательное поле ' + key,
+        params: { keyword: 'isNotEmpty' }
+      }
+    ];
+
+    return typeof data === 'string' && data.trim() !== '';
+  }
+});
+
 export function createValidator(schema, additionalValidator) {
   const validator = ajv.compile(schema);
 


### PR DESCRIPTION
Правило валидации email такое же как в библиотеке, только добавил возможность оставить поле пустым. Как по мне это можно и через required регулировать. 
А isNotEmpty нужен чтобы нельзя было оставить строку пустой. Потому что если просто задано required, то можно ввести что-то в поле, потом стереть и поле будет пустым, но при этом валидным.